### PR TITLE
[#24] [UI] [Android] As a user, I can see the available surveys on the home screen

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -98,4 +98,5 @@ dependencies {
     implementation(Dependency.Compose.NAVIGATION)
     implementation(Dependency.Compose.COIL)
     implementation(Dependency.Firebase.FIREBASE)
+    implementation(Dependency.Compose.FOUNDATION)
 }

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/constants/Colors.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/constants/Colors.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.kaylabruce.kmmic.android.constants
+
+import androidx.compose.ui.graphics.Color
+
+object Colors {
+    val White20 = Color.White.copy(0.2f)
+    val White30 = Color.White.copy(0.3f)
+    val White50 = Color.White.copy(0.5f)
+    val White70 = Color.White.copy(0.7f)
+}

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/navigation/SurveyDestination.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/navigation/SurveyDestination.kt
@@ -9,4 +9,6 @@ sealed class SurveyDestination(val route: String = "") {
     object Splash : SurveyDestination("splash")
 
     object SignIn : SurveyDestination("sign-in")
+
+    object SurveyList : SurveyDestination("survey-list")
 }

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/navigation/SurveyNavigation.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/navigation/SurveyNavigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.*
 import androidx.navigation.compose.*
+import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home.HomeScreen
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.signin.SignInScreen
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.splash.SplashScreen
 
@@ -29,6 +30,10 @@ fun SurveyNavHost(
 
         composable(SurveyDestination.SignIn) {
             SignInScreen()
+        }
+
+        composable(SurveyDestination.SurveyList) {
+            HomeScreen()
         }
     }
 }

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/HorizontalPagerIndicator.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/HorizontalPagerIndicator.kt
@@ -1,0 +1,43 @@
+package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun HorizontalPagerIndicator(
+    pageCount: Int,
+    pagerState: PagerState,
+) {
+    Row(
+        Modifier
+            .height(44.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        repeat(pageCount) { iteration ->
+            val color = if (pagerState.currentPage == iteration) Color.White else Color.DarkGray
+            Box(
+                modifier = Modifier
+                    .padding(3.dp)
+                    .clip(CircleShape)
+                    .background(color)
+                    .size(8.dp),
+            )
+        }
+    }
+}

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/ImageBackground.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/ImageBackground.kt
@@ -1,0 +1,61 @@
+package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+
+private const val GRADIENT_VAL = 0.2f
+@Composable
+fun ImageBackground(
+    @DrawableRes imageRes: Int? = null,
+    imageUrl: String? = null,
+    blurRadius: Dp = 0.dp,
+    gradientAlpha: Float = 1f,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        imageRes?.let {
+            Image(
+                painter = painterResource(id = imageRes),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .matchParentSize()
+                    .blur(radius = blurRadius),
+            )
+        }
+        imageUrl?.let {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .matchParentSize()
+                    .blur(radius = blurRadius),
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Black.copy(gradientAlpha * GRADIENT_VAL),
+                            Color.Black.copy(gradientAlpha),
+                        )
+                    )
+                ),
+        )
+    }
+}

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/ImageBackground.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/ImageBackground.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 
 private const val GRADIENT_VAL = 0.2f
+
 @Composable
 fun ImageBackground(
     @DrawableRes imageRes: Int? = null,

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/NextCircleButton.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/NextCircleButton.kt
@@ -1,0 +1,32 @@
+package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import co.nimblehq.kaylabruce.kmmic.android.R
+
+@Composable
+fun NextCircleButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_arrow_right),
+        contentDescription = null,
+        contentScale = ContentScale.Inside,
+        modifier = modifier
+            .size(60.dp)
+            .clip(CircleShape)
+            .background(Color.White)
+            .clickable { onClick() },
+    )
+}

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/SurveyTextField.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/common/SurveyTextField.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.*
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import co.nimblehq.kaylabruce.kmmic.android.constants.Colors
 
 @Composable
 fun SurveyTextField(
@@ -44,12 +45,12 @@ fun SurveyTextField(
         colors = TextFieldDefaults.textFieldColors(
             textColor = Color.White,
             cursorColor = Color.White,
-            backgroundColor = Color.White.copy(alpha = 0.2f),
+            backgroundColor = Colors.White20,
             focusedIndicatorColor = Color.Transparent,
             unfocusedIndicatorColor = Color.Transparent,
             disabledIndicatorColor = Color.Transparent,
             errorIndicatorColor = Color.Transparent,
-            placeholderColor = Color.White.copy(alpha = 0.3f),
+            placeholderColor = Colors.White30,
         ),
         visualTransformation = visualTransformation,
         keyboardOptions = KeyboardOptions(

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
@@ -1,21 +1,55 @@
 package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.nimblehq.kaylabruce.kmmic.android.constants.Dimens
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home.header.HomeHeaderView
 import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.HomeHeaderUiModel
+import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.ImageBackground
+import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home.footer.HomeFooterView
+import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyListUiModel
+import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyUiModel
 
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen() {
     Scaffold(
         backgroundColor = Color.Black,
     ) { padding ->
+        val pagerState = rememberPagerState()
+        // TODO: Remove dummy data
+        val uiModel = SurveyListUiModel(
+            surveys = listOf(
+                SurveyUiModel(
+                    url = "https://picsum.photos/375/812",
+                    title = "Working from home Check-In",
+                    description = "We would like to know how you feel about our work from home",
+                ),
+                SurveyUiModel(
+                    url = "https://picsum.photos/375/813",
+                    title = "Career training and development",
+                    description = "We would like to know what are your goals and skills you wanted",
+                ),
+                SurveyUiModel(
+                    url = "https://picsum.photos/375/814",
+                    title = "Inclusion and belonging",
+                    description = "Building a workplace culture that prioritizes belonging and inclusion",
+                ),
+            )
+        )
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -23,16 +57,36 @@ fun HomeScreen() {
                 .statusBarsPadding()
                 .padding(all = Dimens.medium.dp),
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
-                HomeHeaderView(
-                    uiModel = HomeHeaderUiModel(
-                    imageUrl = "https://avatars.githubusercontent.com/u/7391673?s=200&v=4",
-                    dateText = "Monday, June 15",
-                    todayText = "Today",
-                    ),
-                ) {
-                    // TODO: Tap profile image
-                    println("Tap profile image")
+            // pullRefresh needs a vertical scroll component to work
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                item {
+                    Box(modifier = Modifier.fillParentMaxHeight()) {
+                        HorizontalPager(
+                            pageCount = uiModel.surveys.count(),
+                            state = pagerState,
+                            modifier = Modifier.fillMaxSize(),
+                        ) { index ->
+                            ImageBackground(
+                                imageUrl = uiModel.surveys[index].url,
+                            )
+                        }
+
+                        HomeHeaderView(
+                            uiModel = HomeHeaderUiModel(
+                                imageUrl = "https://avatars.githubusercontent.com/u/7391673?s=200&v=4",
+                                dateText = "Monday, June 15",
+                                todayText = "Today",
+                            )
+                        ) {
+                            // TODO: Tap profile image
+                            println("Tap profile image")
+                        }
+
+                        HomeFooterView(
+                            pagerState = pagerState,
+                            surveys = uiModel.surveys,
+                        )
+                    }
                 }
             }
         }

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
@@ -21,7 +21,7 @@ import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyListUiMod
 import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyUiModel
 
 // TODO: Remove dummy data
-private val DUMMY_DATA = SurveyListUiModel(
+private val _dummyData = SurveyListUiModel(
     surveys = listOf(
         SurveyUiModel(
             url = "https://picsum.photos/375/812",
@@ -41,7 +41,7 @@ private val DUMMY_DATA = SurveyListUiModel(
     )
 )
 
-private val HEADER_DATA = HomeHeaderUiModel(
+private val _headerData = HomeHeaderUiModel(
     imageUrl = "https://avatars.githubusercontent.com/u/7391673?s=200&v=4",
     dateText = "Monday, June 15",
     todayText = "Today",
@@ -54,7 +54,7 @@ fun HomeScreen() {
         backgroundColor = Color.Black,
     ) { padding ->
         val pagerState = rememberPagerState()
-        val uiModel = DUMMY_DATA
+        val uiModel = _dummyData
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -72,7 +72,7 @@ fun HomeScreen() {
                                 .statusBarsPadding()
                                 .padding(Dimens.medium.dp),
                         ) {
-                            HomeHeader(uiModel = HEADER_DATA)
+                            HomeHeader(uiModel = _headerData)
                             HomeFooter(
                                 uiModel = uiModel.surveys,
                                 pagerState = pagerState,

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
@@ -1,27 +1,51 @@
 package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
-import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.nimblehq.kaylabruce.kmmic.android.constants.Dimens
-import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home.header.HomeHeaderView
-import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.HomeHeaderUiModel
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.ImageBackground
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home.footer.HomeFooterView
+import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home.header.HomeHeaderView
+import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.HomeHeaderUiModel
 import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyListUiModel
 import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyUiModel
 
+// TODO: Remove dummy data
+private val DUMMY_DATA = SurveyListUiModel(
+    surveys = listOf(
+        SurveyUiModel(
+            url = "https://picsum.photos/375/812",
+            title = "Working from home Check-In",
+            description = "We would like to know how you feel about our work from home",
+        ),
+        SurveyUiModel(
+            url = "https://picsum.photos/375/813",
+            title = "Career training and development",
+            description = "We would like to know what are your goals and skills you wanted",
+        ),
+        SurveyUiModel(
+            url = "https://picsum.photos/375/814",
+            title = "Inclusion and belonging",
+            description = "Building a workplace culture that prioritizes belonging and inclusion",
+        ),
+    )
+)
+
+private val HEADER_DATA = HomeHeaderUiModel(
+    imageUrl = "https://avatars.githubusercontent.com/u/7391673?s=200&v=4",
+    dateText = "Monday, June 15",
+    todayText = "Today",
+)
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -30,64 +54,28 @@ fun HomeScreen() {
         backgroundColor = Color.Black,
     ) { padding ->
         val pagerState = rememberPagerState()
-        // TODO: Remove dummy data
-        val uiModel = SurveyListUiModel(
-            surveys = listOf(
-                SurveyUiModel(
-                    url = "https://picsum.photos/375/812",
-                    title = "Working from home Check-In",
-                    description = "We would like to know how you feel about our work from home",
-                ),
-                SurveyUiModel(
-                    url = "https://picsum.photos/375/813",
-                    title = "Career training and development",
-                    description = "We would like to know what are your goals and skills you wanted",
-                ),
-                SurveyUiModel(
-                    url = "https://picsum.photos/375/814",
-                    title = "Inclusion and belonging",
-                    description = "Building a workplace culture that prioritizes belonging and inclusion",
-                ),
-            )
-        )
+        val uiModel = DUMMY_DATA
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
+                .padding(padding),
         ) {
-            // pullRefresh needs a vertical scroll component to work
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 item {
                     Box(modifier = Modifier.fillParentMaxHeight()) {
-                        HorizontalPager(
-                            pageCount = uiModel.surveys.count(),
-                            state = pagerState,
-                            modifier = Modifier.fillMaxSize(),
-                        ) { index ->
-                            ImageBackground(
-                                imageUrl = uiModel.surveys[index].url,
-                            )
-                        }
-
+                        BackgroundImage(
+                            uiModel = uiModel,
+                            pagerState = pagerState,
+                        )
                         Box(
                             modifier = Modifier
                                 .statusBarsPadding()
                                 .padding(Dimens.medium.dp),
                         ) {
-                            HomeHeaderView(
-                                uiModel = HomeHeaderUiModel(
-                                    imageUrl = "https://avatars.githubusercontent.com/u/7391673?s=200&v=4",
-                                    dateText = "Monday, June 15",
-                                    todayText = "Today",
-                                ),
-                            ) {
-                                // TODO: Tap profile image
-                                println("Tap profile image")
-                            }
-
-                            HomeFooterView(
+                            HomeHeader(uiModel = HEADER_DATA)
+                            HomeFooter(
+                                uiModel = uiModel.surveys,
                                 pagerState = pagerState,
-                                surveys = uiModel.surveys,
                             )
                         }
                     }
@@ -95,6 +83,44 @@ fun HomeScreen() {
             }
         }
     }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun BackgroundImage(
+    uiModel: SurveyListUiModel,
+    pagerState: PagerState,
+) {
+    HorizontalPager(
+        pageCount = uiModel.surveys.count(),
+        state = pagerState,
+        modifier = Modifier.fillMaxSize(),
+    ) { index ->
+        ImageBackground(
+            imageUrl = uiModel.surveys[index].url,
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun HomeHeader(uiModel: HomeHeaderUiModel) {
+    HomeHeaderView(uiModel = uiModel) {
+        // TODO: Tap profile image
+        println("Tap profile image")
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun HomeFooter(
+    pagerState: PagerState,
+    uiModel: List<SurveyUiModel>,
+) {
+    HomeFooterView(
+        pagerState = pagerState,
+        surveys = uiModel,
+    )
 }
 
 @Preview

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/HomeScreen.kt
@@ -54,8 +54,6 @@ fun HomeScreen() {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .statusBarsPadding()
-                .padding(all = Dimens.medium.dp),
         ) {
             // pullRefresh needs a vertical scroll component to work
             LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -71,21 +69,27 @@ fun HomeScreen() {
                             )
                         }
 
-                        HomeHeaderView(
-                            uiModel = HomeHeaderUiModel(
-                                imageUrl = "https://avatars.githubusercontent.com/u/7391673?s=200&v=4",
-                                dateText = "Monday, June 15",
-                                todayText = "Today",
-                            )
+                        Box(
+                            modifier = Modifier
+                                .statusBarsPadding()
+                                .padding(Dimens.medium.dp),
                         ) {
-                            // TODO: Tap profile image
-                            println("Tap profile image")
-                        }
+                            HomeHeaderView(
+                                uiModel = HomeHeaderUiModel(
+                                    imageUrl = "https://avatars.githubusercontent.com/u/7391673?s=200&v=4",
+                                    dateText = "Monday, June 15",
+                                    todayText = "Today",
+                                ),
+                            ) {
+                                // TODO: Tap profile image
+                                println("Tap profile image")
+                            }
 
-                        HomeFooterView(
-                            pagerState = pagerState,
-                            surveys = uiModel.surveys,
-                        )
+                            HomeFooterView(
+                                pagerState = pagerState,
+                                surveys = uiModel.surveys,
+                            )
+                        }
                     }
                 }
             }

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/footer/HomeFooterView.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/footer/HomeFooterView.kt
@@ -1,0 +1,90 @@
+package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.home.footer
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import co.nimblehq.kaylabruce.kmmic.android.constants.Colors
+import co.nimblehq.kaylabruce.kmmic.android.constants.Dimens
+import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.HorizontalPagerIndicator
+import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.NextCircleButton
+import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyUiModel
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun HomeFooterView(
+    pagerState: PagerState,
+    surveys: List<SurveyUiModel>,
+) {
+    var survey by remember { mutableStateOf<SurveyUiModel?>(null) }
+    LaunchedEffect(surveys) {
+        snapshotFlow { pagerState.currentPage }.collect { index ->
+            survey = surveys.getOrNull(index)
+        }
+    }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Bottom,
+    ) {
+        HorizontalPagerIndicator(
+            pageCount = surveys.count(),
+            pagerState = pagerState,
+        )
+        Crossfade(
+            targetState = survey?.title.orEmpty(),
+            label = "",
+            ) {
+            Text(
+                text = it,
+                color = Color.White,
+                style = MaterialTheme.typography.h5,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(modifier = Modifier.height(Dimens.small.dp))
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Crossfade(
+                targetState = survey?.description.orEmpty(),
+                modifier = Modifier.weight(1f),
+                label = "",
+            ) {
+                Text(
+                    text = it,
+                    color = Colors.White70,
+                    style = MaterialTheme.typography.body1,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(modifier = Modifier.width(Dimens.medium.dp))
+            NextCircleButton(
+                // TODO: Integration task
+                onClick = {},
+            )
+        }
+    }
+}

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/header/HomeHeaderView.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/header/HomeHeaderView.kt
@@ -40,7 +40,7 @@ fun HomeHeaderView(
         ) {
             Text(
                 text = uiModel.todayText,
-                style = MaterialTheme.typography.caption,
+                style = MaterialTheme.typography.h3,
                 color = Color.White,
             )
             AsyncImage(

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/header/HomeHeaderView.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/home/header/HomeHeaderView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -27,6 +28,7 @@ fun HomeHeaderView(
     Column {
        Text(
            text = uiModel.dateText.uppercase(),
+           style = MaterialTheme.typography.h5,
            color = Color.White,
            )
         Spacer(
@@ -38,6 +40,7 @@ fun HomeHeaderView(
         ) {
             Text(
                 text = uiModel.todayText,
+                style = MaterialTheme.typography.caption,
                 color = Color.White,
             )
             AsyncImage(

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/signin/SignInScreen.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/signin/SignInScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.input.*
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.nimblehq.kaylabruce.kmmic.android.R
+import co.nimblehq.kaylabruce.kmmic.android.constants.Colors
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.SurveyButton
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.SurveyTextField
 import kotlinx.coroutines.delay
@@ -102,7 +103,7 @@ fun SignInForm() {
             trailingIcon = {
                 Text(
                     text = "Forgot?",
-                    color = Color.White.copy(alpha = 0.5f),
+                    color = Colors.White50,
                     modifier = Modifier
                         .padding(all = 16.dp),
                 )

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/uimodel/SurveyListUiModel.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/uimodel/SurveyListUiModel.kt
@@ -1,0 +1,11 @@
+package co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel
+
+data class SurveyListUiModel(
+    val surveys: List<SurveyUiModel>,
+)
+
+data class SurveyUiModel(
+    val url: String,
+    val title: String,
+    val description: String,
+)

--- a/android/src/main/res/drawable/ic_arrow_right.xml
+++ b/android/src/main/res/drawable/ic_arrow_right.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="21dp"
+    android:viewportWidth="12"
+    android:viewportHeight="21">
+  <path
+      android:pathData="M2.463,20.083L11.708,10.946C12.097,10.561 12.097,9.94 11.708,9.554L2.463,0.417C1.901,-0.139 0.986,-0.139 0.422,0.417C-0.14,0.974 -0.14,1.877 0.422,2.433L8.331,10.25L0.422,18.066C-0.14,18.623 -0.14,19.526 0.422,20.083C0.986,20.639 1.901,20.639 2.463,20.083Z"
+      android:fillColor="#15151A"
+      android:fillType="evenOdd" />
+</vector>

--- a/buildSrc/src/main/kotlin/appPackage/Dependency.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Dependency.kt
@@ -19,6 +19,7 @@ object Dependency {
         val MATERIAL by lazy { "androidx.compose.material:material:${Version.COMPOSE_MATERIAL}" }
         val NAVIGATION by lazy { "androidx.navigation:navigation-compose:${Version.COMPOSE_NAVIGATION}" }
         val COIL by lazy { "io.coil-kt:coil-compose:${Version.COMPOSE_COIL}" }
+        val FOUNDATION by lazy { "androidx.compose.foundation:foundation:${Version.COMPOSE_FOUNDATION}" }
     }
 
     object Kover {

--- a/buildSrc/src/main/kotlin/appPackage/Version.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Version.kt
@@ -16,4 +16,5 @@ object Version {
     const val COMPOSE_COIL = "2.4.0"
     const val GOOGLE_SERVICES = "4.3.15"
     const val FIREBASE = "31.5.0"
+    const val COMPOSE_FOUNDATION = "1.4.3"
 }


### PR DESCRIPTION
- Close #24

## What happened 👀

In this PR, I implemented the survey list on the home screen for Android:

- Show a series of small indicator dots representing the available item in the order they were opened. A solid dot denotes the current page. Users cannot tap on a specific dot to go to a specific page.

- Show a horizontal collection view page. Each page contains the title and description of the survey.

- The screen's background is according to the cover image URL of the current survey onscreen.

- The user can navigate to the next/previous item by swiping the page to one side.

- A circle button to go to take the survey.

## Insight 📝

N/A

## Proof Of Work 📹

<img src="https://github.com/nimblehq/ic-kmm-kayla-bruce/assets/23162627/0c5b204c-0368-4092-a44f-ce8207d855c8" width=200 />
