### PR TITLE
[#46] [UI] [Android] As a user, I can see the general UI for question

### DIFF
--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/surveyquestion/SurveyQuestionScreen.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/screen/surveyquestion/SurveyQuestionScreen.kt
@@ -1,15 +1,10 @@
-package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.surveydetail
+package co.nimblehq.kaylabruce.kmmic.android.presentation.screen.surveyquestion
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,22 +17,25 @@ import co.nimblehq.kaylabruce.kmmic.android.R
 import co.nimblehq.kaylabruce.kmmic.android.constants.Colors
 import co.nimblehq.kaylabruce.kmmic.android.constants.Dimens
 import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.ImageBackground
-import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyDetailUiModel
+import co.nimblehq.kaylabruce.kmmic.android.presentation.screen.common.NextCircleButton
+import co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel.SurveyQuestionUiModel
 
 // TODO: - Remove dummy data
-private val _dummyData = SurveyDetailUiModel(
+private val _dummyData = SurveyQuestionUiModel(
     imageUrl = "https://picsum.photos/375/813",
-    titleText = "Working from home Check-In",
-    descriptionText = "We would like to know how you feel about our work from home (WFH) experience.",
+    questionNumber = 3,
+    totalQuestion = 10,
+    questionTitle = "How fulfilled did you feel during this WFH period?",
+    isLastQuestion = true,
 )
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun SurveyDetailScreen() {
+fun SurveyQuestionScreen() {
+    val uiModel = _dummyData
     Scaffold(
         backgroundColor = Color.Black,
     ) { padding ->
-        val uiModel = _dummyData
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -55,19 +53,24 @@ fun SurveyDetailScreen() {
                             Column(
                                 verticalArrangement = Arrangement.SpaceBetween,
                                 modifier = Modifier.fillMaxSize(),
-                                ) {
+                            ) {
                                 Column {
-                                    BackButton()
+                                    Row(
+                                        horizontalArrangement = Arrangement.End,
+                                        modifier = Modifier.fillMaxWidth(),
+                                    )  {
+                                        CloseButton()
+                                    }
                                     Spacer(modifier = Modifier.height(Dimens.medium.dp))
-                                    TitleText(text = uiModel.titleText)
+                                    QuestionNumberText(text = uiModel.questionIndex)
                                     Spacer(modifier = Modifier.height(Dimens.small.dp))
-                                    DescriptionText(text = uiModel.descriptionText)
+                                    QuestionTittleText(text = uiModel.questionTitle)
                                 }
                                 Row(
                                     horizontalArrangement = Arrangement.End,
                                     modifier = Modifier.fillMaxWidth(),
                                 )  {
-                                    StartButton()
+                                    PrimaryButton(isLastQuestion = uiModel.isLastQuestion)
                                 }
                             }
                         }
@@ -88,33 +91,22 @@ private fun BackgroundImage(imageUrl: String) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun BackButton() {
+private fun CloseButton() {
     Image(
-        painter = painterResource(id = R.drawable.ic_back),
+        painter = painterResource(id = R.drawable.ic_close),
         contentDescription = null,
         contentScale = ContentScale.Inside,
         modifier = Modifier
             .size(30.dp)
             .clickable {
-                // TODO: - Navigate back
+                // TODO: - Close question
             },
     )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun TitleText(text: String) {
-    Text(
-        text = text,
-        color = Color.White,
-        style = MaterialTheme.typography.h4,
-        overflow = TextOverflow.Ellipsis,
-    )
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun DescriptionText(text: String) {
+private fun QuestionNumberText(text: String) {
     Text(
         text = text,
         color = Colors.White70,
@@ -126,16 +118,42 @@ private fun DescriptionText(text: String) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun StartButton() {
+private fun QuestionTittleText(text: String) {
+    Text(
+        text = text,
+        color = Color.White,
+        style = MaterialTheme.typography.h4,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun PrimaryButton(isLastQuestion: Boolean) {
+    if (isLastQuestion) SubmitButton() else NextButton()
+}
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun NextButton() {
+    NextCircleButton(
+        onClick = {
+                  // Todo: - Navigate to the next question
+        },
+        )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SubmitButton() {
     Button(
         contentPadding = PaddingValues(Dimens.medium.dp),
         onClick = {
-        // TODO: - Navigate to question screen
+            // TODO: - Submit answers and show lottie
         },
         colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
-        ) {
+    ) {
         Text(
-            text = "Start Survey",
+            text = "Submit",
             color = Color.Black,
             style = MaterialTheme.typography.body1,
             maxLines = 2,
@@ -146,6 +164,6 @@ private fun StartButton() {
 
 @Preview
 @Composable
-fun PreviewSurveyDetailScreen() {
-    SurveyDetailScreen()
+private fun PreviewSurveyQuestionScreen() {
+    SurveyQuestionScreen()
 }

--- a/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/uimodel/SurveyQuestionUiModel.kt
+++ b/android/src/main/java/co/nimblehq/kaylabruce/kmmic/android/presentation/uimodel/SurveyQuestionUiModel.kt
@@ -1,0 +1,12 @@
+package co.nimblehq.kaylabruce.kmmic.android.presentation.uimodel
+
+data class SurveyQuestionUiModel(
+    val imageUrl: String,
+    val questionNumber: Int,
+    val totalQuestion: Int,
+    val questionTitle: String,
+    val isLastQuestion: Boolean,
+) {
+    val questionIndex: String
+        get() =  "$questionNumber/$totalQuestion"
+}

--- a/android/src/main/res/drawable/ic_close.xml
+++ b/android/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="30dp"
+    android:viewportWidth="28"
+    android:viewportHeight="30">
+  <path
+      android:pathData="M14,29C21.732,29 28,22.732 28,15C28,7.268 21.732,1 14,1C6.268,1 0,7.268 0,15C0,22.732 6.268,29 14,29Z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="M8.855,9.855C8.382,10.329 8.382,11.097 8.855,11.57L12.285,15L8.855,18.43C8.382,18.903 8.382,19.671 8.855,20.145C9.329,20.618 10.097,20.618 10.57,20.145L14,16.715L17.43,20.145C17.903,20.618 18.671,20.618 19.145,20.145C19.618,19.671 19.618,18.903 19.145,18.43L15.715,15L19.145,11.57C19.618,11.097 19.618,10.329 19.145,9.855C18.671,9.382 17.903,9.382 17.43,9.855L14,13.285L10.57,9.855C10.097,9.382 9.329,9.382 8.855,9.855Z"
+      android:fillColor="#ffffff"
+      android:fillAlpha="0.92"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
- Close #46

## What happened 👀

In this PR, I implemented the UI for the general question on Android:

- Background image of the survey
- Close button on the top right corner
- Question index
- Question text
- (Answers will be implemented in other tasks)
- If the question is the last question of the survey, show the `Submit Survey` button in the bottom right corner. If not, show the next button instead.


## Insight 📝

N/A

## Proof Of Work 📹

<img src="https://github.com/nimblehq/ic-kmm-kayla-bruce/assets/23162627/98cf2f46-8f41-4970-a94b-3f7b5239fe0f" width=200 /> <img src="https://github.com/nimblehq/ic-kmm-kayla-bruce/assets/23162627/b4caac63-3ed2-453d-aea8-ced21221061c" width=200 />


