### PR TITLE
[#21] [Backend] As a user, I can see the available surveys on the home screen

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -39,7 +39,7 @@ android {
     buildTypes {
         getByName(Configuration.BuildTypes.RELEASE) {
             isMinifyEnabled = true
-            isDebuggable = false
+            isDebuggable = true
             isShrinkResources = true
             signingConfig = signingConfigs[Configuration.BuildTypes.RELEASE]
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/extension/ResponseMapping.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/extension/ResponseMapping.kt
@@ -1,0 +1,25 @@
+package co.nimblehq.kaylabruce.kmmic.data.extension
+
+import co.nimblehq.jsonapi.model.JsonApiException
+import co.nimblehq.kaylabruce.kmmic.domain.exeption.ApiException
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlin.experimental.ExperimentalTypeInference
+
+@OptIn(ExperimentalTypeInference::class)
+fun <T> flowTransform(@BuilderInference block: suspend FlowCollector<T>.() -> T) = flow {
+    runCatching { block() }
+        .onSuccess { emit(it) }
+        .onFailure { throw it.mapError() }
+}
+
+private fun Throwable.mapError(): Throwable =
+    when (this) {
+        is JsonApiException -> ApiException(
+            code = errors.first().code,
+            message = errors.first().detail,
+            cause = this
+        )
+
+        else -> this
+    }

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/remote/model/response/SurveyResponse.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/remote/model/response/SurveyResponse.kt
@@ -1,0 +1,24 @@
+package co.nimblehq.kaylabruce.kmmic.data.remote.model.response
+
+import co.nimblehq.kaylabruce.kmmic.domain.model.Survey
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SurveyResponse(
+    @SerialName("id")
+    val id: String,
+    @SerialName("title")
+    val title: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("cover_image_url")
+    val coverImageUrl: String,
+)
+
+fun SurveyResponse.toSurvey() = Survey(
+    id = id,
+    title = title,
+    description = description,
+    coverImageUrl = coverImageUrl,
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/remote/service/SurveyService.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/remote/service/SurveyService.kt
@@ -1,0 +1,21 @@
+package co.nimblehq.kaylabruce.kmmic.data.remote.service
+
+import co.nimblehq.kaylabruce.kmmic.data.remote.model.response.SurveyResponse
+
+interface SurveyService {
+    suspend fun getSurveyList(
+        pageNumber: Int,
+        pageSize: Int,
+    ): List<SurveyResponse>
+}
+
+class SurveyServiceImpl(private val apiClient: ApiClient) : SurveyService {
+    override suspend fun getSurveyList(
+        pageNumber: Int,
+        pageSize: Int
+    ): List<SurveyResponse> {
+        return apiClient.get<List<SurveyResponse>>(
+            path = "api/v1/surveys?page[number]=$pageNumber&page[size]=$pageSize"
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/data/repository/SurveyRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package co.nimblehq.kaylabruce.kmmic.data.repository
+
+import co.nimblehq.kaylabruce.kmmic.data.extension.flowTransform
+import co.nimblehq.kaylabruce.kmmic.data.remote.model.response.toSurvey
+import co.nimblehq.kaylabruce.kmmic.data.remote.service.SurveyService
+import co.nimblehq.kaylabruce.kmmic.domain.model.Survey
+import co.nimblehq.kaylabruce.kmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+
+class SurveyRepositoryImpl(
+    private val surveyRemoteDataSource: SurveyService,
+) : SurveyRepository {
+    override fun getSurveyList(
+        pageNumber: Int,
+        pageSize: Int,
+    ): Flow<List<Survey>> = flowTransform {
+        surveyRemoteDataSource
+            .getSurveyList(
+                pageNumber = pageNumber,
+                pageSize = pageSize,
+            )
+            .map {
+                val surveys = it
+                surveys.toSurvey()
+            }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/di/RemoteModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/di/RemoteModule.kt
@@ -3,6 +3,7 @@ package co.nimblehq.kaylabruce.kmmic.di
 import co.nimblehq.kaylabruce.kmmic.data.remote.service.*
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 private const val UNAUTHORIZED_API_CLIENT = "unauthorized_api_client"
@@ -11,4 +12,5 @@ val remoteModule = module {
     singleOf(::ApiClient)
     single(named(UNAUTHORIZED_API_CLIENT)) { ApiClient(get()) }
     single<AuthService> { AuthServiceImpl(get(named(UNAUTHORIZED_API_CLIENT))) }
+    singleOf(::SurveyServiceImpl) bind SurveyService::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/di/RepositoryModule.kt
@@ -1,11 +1,14 @@
 package co.nimblehq.kaylabruce.kmmic.di
 
 import co.nimblehq.kaylabruce.kmmic.data.repository.AuthRepositoryImpl
+import co.nimblehq.kaylabruce.kmmic.data.repository.SurveyRepositoryImpl
 import co.nimblehq.kaylabruce.kmmic.domain.repository.AuthRepository
+import co.nimblehq.kaylabruce.kmmic.domain.repository.SurveyRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val repositoryModule = module {
     singleOf(::AuthRepositoryImpl) bind AuthRepository::class
+    singleOf(::SurveyRepositoryImpl) bind SurveyRepository::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/di/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/di/UseCaseModule.kt
@@ -1,9 +1,11 @@
 package co.nimblehq.kaylabruce.kmmic.di
 
-import co.nimblehq.kaylabruce.kmmic.domain.usecase.RefreshTokenUseCase
+import co.nimblehq.kaylabruce.kmmic.domain.usecase.*
 import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val useCaseModule = module {
     singleOf(::RefreshTokenUseCase)
+    singleOf(::GetSurveyListUseCaseImpl) bind GetSurveyListUseCase::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/exeption/ApiExeption.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/exeption/ApiExeption.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.kaylabruce.kmmic.domain.exeption
+
+data class ApiException(
+    val code: String?,
+    override val message: String?,
+    override val cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/model/Survey.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/model/Survey.kt
@@ -1,0 +1,8 @@
+package co.nimblehq.kaylabruce.kmmic.domain.model
+
+data class Survey(
+    val id: String,
+    val title: String,
+    val description: String,
+    val coverImageUrl: String,
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/repository/SurveyRepository.kt
@@ -1,0 +1,11 @@
+package co.nimblehq.kaylabruce.kmmic.domain.repository
+
+import co.nimblehq.kaylabruce.kmmic.domain.model.Survey
+import kotlinx.coroutines.flow.Flow
+
+interface SurveyRepository {
+    fun getSurveyList(
+        pageNumber: Int,
+        pageSize: Int,
+    ): Flow<List<Survey>>
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/usecase/GetSurveyListUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kaylabruce/kmmic/domain/usecase/GetSurveyListUseCase.kt
@@ -1,0 +1,27 @@
+package co.nimblehq.kaylabruce.kmmic.domain.usecase
+
+import co.nimblehq.kaylabruce.kmmic.domain.model.Survey
+import co.nimblehq.kaylabruce.kmmic.domain.model.Token
+import co.nimblehq.kaylabruce.kmmic.domain.repository.AuthRepository
+import co.nimblehq.kaylabruce.kmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
+
+interface GetSurveyListUseCase {
+    operator fun invoke(
+        pageNumber: Int,
+        pageSize: Int,
+    ): Flow<List<Survey>>
+}
+
+class GetSurveyListUseCaseImpl(private val repository: SurveyRepository) : GetSurveyListUseCase {
+    override fun invoke(
+        pageNumber: Int,
+        pageSize: Int,
+    ): Flow<List<Survey>> {
+        return repository.getSurveyList(
+            pageNumber = pageNumber,
+            pageSize = pageSize,
+        )
+    }
+}


### PR DESCRIPTION
- Close #21

## What happened 👀

In this PR, I implement the backend for getting the survey list. 
By calling the API GET `/api/v1/surveys` to get the list of surveys, use default `page[number]=1` and `page[size]=10`.

## Insight 📝

N/A

## Proof Of Work 📹

N/A
